### PR TITLE
Add component meta data and group no group components correctly

### DIFF
--- a/src/integrations/ditto/client/types.ts
+++ b/src/integrations/ditto/client/types.ts
@@ -27,6 +27,8 @@ export type WorkspaceComponent = {
   name: string
   text: string
   status: string
+  notes?: string
+  tags?: string[]
   folder: string
   variants: Record<string, Variant>
 }

--- a/src/modules/cache/CacheService.ts
+++ b/src/modules/cache/CacheService.ts
@@ -57,7 +57,7 @@ export class CacheService {
           folder: data.folder || '',
           status: data.status || '',
           notes: data.notes || '',
-          tags: data.tags.join(" ") || '',
+          tags: data.tags?.join(" ") || '',
         },
         title: parsedName.name,
         groupTitle: parsedName.groupName || 'Other components',

--- a/src/modules/cache/CacheService.ts
+++ b/src/modules/cache/CacheService.ts
@@ -51,13 +51,16 @@ export class CacheService {
 
       return {
         uniqueId: id,
-        groupId: parsedName.groupName?.replaceAll(' ', '') || id,
+        groupId: parsedName.groupName?.replaceAll(' ', '') || "Other components",
         metadata: {},
         fields: {
           folder: data.folder || '',
+          status: data.status || '',
+          notes: data.notes || '',
+          tags: data.tags.join(" ") || '',
         },
         title: parsedName.name,
-        groupTitle: parsedName.groupName || 'No group',
+        groupTitle: parsedName.groupName || 'Other components',
       }
     })
   }

--- a/src/modules/env/EnvService.ts
+++ b/src/modules/env/EnvService.ts
@@ -10,6 +10,9 @@ export class EnvService {
   async getCacheItemStructure() {
     return Promise.resolve({
       folder: 'Folder',
+      status: 'Status',
+      notes: 'Notes',
+      tags: 'Tags',
     })
   }
 }


### PR DESCRIPTION
The PR accomplishes the following:
- Adds the status, notes, and tags, columns when importing Ditto components
- Groups components that are not in a Ditto group as "Other components"
- Fixes no group component grouping

Note: I haven't tested any of these changes so will need someone at Lokalise to verify they work. Thanks!